### PR TITLE
Update README with latest stable Appium version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ brew install node
 ```
 
 Install Appium
-Safest version at the moment is 1.2.1.
+Safest version at the moment is 1.3.6.
 
 ```
-npm install appium@1.2.1
+npm install appium@1.3.6
 ```
 
 ### Ubuntu


### PR DESCRIPTION
Is the version number of appium required here? At http://appium.io/getting-started.html they suggest simply 'npm install -g appium'